### PR TITLE
Added tests for creation of TGW and attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Tests for checking paused cluster state
 * Test for checking registrars get called
 * Test for cluster not existing
+* Tests to cover creation of TGW and attachments
 
 ## [0.0.1] - 2022-09-06
 

--- a/controllers/networktopology.go
+++ b/controllers/networktopology.go
@@ -66,7 +66,7 @@ func (r *NetworkTopologyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if annotations.IsPaused(cluster, cluster) {
 		logger.Info("Core cluster is marked as paused. Won't reconcile")
-		return ctrl.Result{Requeue: false}, nil
+		return ctrl.Result{}, nil
 	}
 
 	if !cluster.DeletionTimestamp.IsZero() {
@@ -88,7 +88,7 @@ func (r *NetworkTopologyReconciler) reconcileNormal(ctx context.Context, cluster
 			if errors.Is(err, &registrar.ModeNotSupportedError{}) {
 				return ctrl.Result{Requeue: false}, nil
 			}
-			return ctrl.Result{}, microerror.Mask(err)
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 10}, microerror.Mask(err)
 		}
 	}
 


### PR DESCRIPTION
This PR:

- Adds tests covering the creation of TGWs and the attachments for both MCs and WCs
- Changed the requeue logic to ensure WCs that fail to get TGW from the MC re-try again later
- Fixed creation of TGW attachment by checking for an existing attachment first

### Testing

Description on how aws-network-topology-operator can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for aws-network-topology-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
