### PR TITLE
Initialise client after controller has started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Initialise AWS client after controller has been started (see https://github.com/kubernetes-sigs/controller-runtime/issues/607)
+
 ## [0.1.3] - 2022-09-16
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -114,13 +114,7 @@ func main() {
 	}
 	client := k8sclient.NewCluster(mgr.GetClient(), managementCluster)
 
-	identity, err := client.GetAWSClusterRoleIdentity(ctx, managementCluster)
-	if err != nil {
-		setupLog.Error(err, "failed to get ClusterRoleIdentity of management cluster")
-		os.Exit(1)
-	}
-	roleARN := identity.Spec.RoleArn
-	ec2Service := aws.NewEC2Client(ctx, roleARN)
+	ec2Service := aws.NewEC2Client(ctx, client, managementCluster)
 
 	registrars := []controllers.Registrar{
 		registrar.NewTransitGateway(ec2Service, client),


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how aws-network-topology-operator can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for aws-network-topology-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
