### PR TITLE
Fix TGW attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Check TGW state before attempting to create attachment
+
 ## [0.1.5] - 2022-09-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Check TGW state before attempting to create attachment
 
+### Fixed
+
+- Use only one subnet per AZ for TGW attachment
+
 ## [0.1.5] - 2022-09-16
 
 ### Fixed

--- a/controllers/networktopology.go
+++ b/controllers/networktopology.go
@@ -87,7 +87,10 @@ func (r *NetworkTopologyReconciler) reconcileNormal(ctx context.Context, cluster
 		if err != nil {
 			if errors.Is(err, &registrar.ModeNotSupportedError{}) {
 				return ctrl.Result{Requeue: false}, nil
+			} else if errors.Is(err, &registrar.TransitGatewayNotAvailableError{}) {
+				return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 1}, nil
 			}
+
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 10}, microerror.Mask(err)
 		}
 	}

--- a/controllers/networktopology_test.go
+++ b/controllers/networktopology_test.go
@@ -452,6 +452,7 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 						&ec2.CreateTransitGatewayOutput{
 							TransitGateway: &awstypes.TransitGateway{
 								TransitGatewayId: &transitGatewayID,
+								State:            awstypes.TransitGatewayStateAvailable,
 							},
 						},
 						nil,
@@ -536,7 +537,10 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					transitGatewayClient.DescribeTransitGatewaysReturns(
 						&ec2.DescribeTransitGatewaysOutput{
 							TransitGateways: []awstypes.TransitGateway{
-								{TransitGatewayId: &transitGatewayID},
+								{
+									TransitGatewayId: &transitGatewayID,
+									State:            awstypes.TransitGatewayStateAvailable,
+								},
 							},
 						},
 						nil,
@@ -617,7 +621,10 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					transitGatewayClient.DescribeTransitGatewaysReturns(
 						&ec2.DescribeTransitGatewaysOutput{
 							TransitGateways: []awstypes.TransitGateway{
-								{TransitGatewayId: &transitGatewayID},
+								{
+									TransitGatewayId: &transitGatewayID,
+									State:            awstypes.TransitGatewayStateAvailable,
+								},
 							},
 						},
 						nil,
@@ -697,7 +704,10 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					transitGatewayClient.DescribeTransitGatewaysReturns(
 						&ec2.DescribeTransitGatewaysOutput{
 							TransitGateways: []awstypes.TransitGateway{
-								{TransitGatewayId: &transitGatewayID},
+								{
+									TransitGatewayId: &transitGatewayID,
+									State:            awstypes.TransitGatewayStateAvailable,
+								},
 							},
 						},
 						nil,
@@ -788,7 +798,10 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					transitGatewayClient.DescribeTransitGatewaysReturns(
 						&ec2.DescribeTransitGatewaysOutput{
 							TransitGateways: []awstypes.TransitGateway{
-								{TransitGatewayId: &transitGatewayID},
+								{
+									TransitGatewayId: &transitGatewayID,
+									State:            awstypes.TransitGatewayStateAvailable,
+								},
 							},
 						},
 						nil,
@@ -878,7 +891,10 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					transitGatewayClient.DescribeTransitGatewaysReturns(
 						&ec2.DescribeTransitGatewaysOutput{
 							TransitGateways: []awstypes.TransitGateway{
-								{TransitGatewayId: &transitGatewayID},
+								{
+									TransitGatewayId: &transitGatewayID,
+									State:            awstypes.TransitGatewayStateAvailable,
+								},
 							},
 						},
 						nil,

--- a/pkg/registrar/errors.go
+++ b/pkg/registrar/errors.go
@@ -18,3 +18,15 @@ func (e *ModeNotSupportedError) Error() string {
 func (e *ModeNotSupportedError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
+
+type TransitGatewayNotAvailableError struct {
+	error
+}
+
+func (e *TransitGatewayNotAvailableError) Error() string {
+	return "transit gateway not available"
+}
+
+func (e *TransitGatewayNotAvailableError) Is(target error) bool {
+	return reflect.TypeOf(target) == reflect.TypeOf(e)
+}

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -118,9 +118,14 @@ func (r *TransitGateway) Register(ctx context.Context, cluster *capi.Cluster) er
 			return err
 		}
 
+		if tgw.State == types.TransitGatewayStateAvailable {
 		if err := r.attachTransitGateway(ctx, tgw.TransitGatewayId, cluster); err != nil {
 			logger.Error(err, "Failed to attach transit gateway to cluster VPC")
 			return err
+		}
+		} else {
+			logger.Info("transit gateway not available, skipping attachment for now", "tgwState", tgw.State)
+			return &TransitGatewayNotAvailableError{}
 		}
 
 	default:


### PR DESCRIPTION

This PR:

- Adds check TGW state before attempting to create attachment
- Use only one subnet per AZ for TGW attachment

### Testing

Description on how aws-network-topology-operator can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for aws-network-topology-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
