### PR TITLE
Add routes to subnet route tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add TGW route to cluster subnet route tables
+
 ## [0.1.7] - 2022-09-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Create Prefix List for use with the TGW routing
+- Added `network-topology.giantswarm.io/prefix-list` annotation support
+
 ### Fixed
 
 - Add TGW route to cluster subnet route tables

--- a/controllers/networktopology_test.go
+++ b/controllers/networktopology_test.go
@@ -509,7 +509,7 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 
 					_, payload, _ := transitGatewayClient.CreateTransitGatewayVpcAttachmentArgsForCall(0)
 					Expect(payload.TagSpecifications).To(ContainElement(awstypes.TagSpecification{
-						ResourceType: awstypes.ResourceTypeTransitGateway,
+						ResourceType: awstypes.ResourceTypeTransitGatewayAttachment,
 						Tags: []awstypes.Tag{
 							{
 								Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", request.Name)),
@@ -593,7 +593,7 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 
 					_, payload, _ := transitGatewayClient.CreateTransitGatewayVpcAttachmentArgsForCall(0)
 					Expect(payload.TagSpecifications).To(ContainElement(awstypes.TagSpecification{
-						ResourceType: awstypes.ResourceTypeTransitGateway,
+						ResourceType: awstypes.ResourceTypeTransitGatewayAttachment,
 						Tags: []awstypes.Tag{
 							{
 								Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", request.Name)),
@@ -760,7 +760,7 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 
 					_, payload, _ := transitGatewayClient.CreateTransitGatewayVpcAttachmentArgsForCall(0)
 					Expect(payload.TagSpecifications).To(ContainElement(awstypes.TagSpecification{
-						ResourceType: awstypes.ResourceTypeTransitGateway,
+						ResourceType: awstypes.ResourceTypeTransitGatewayAttachment,
 						Tags: []awstypes.Tag{
 							{
 								Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", request.Name)),
@@ -854,7 +854,7 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 
 					_, payload, _ := transitGatewayClient.CreateTransitGatewayVpcAttachmentArgsForCall(0)
 					Expect(payload.TagSpecifications).To(ContainElement(awstypes.TagSpecification{
-						ResourceType: awstypes.ResourceTypeTransitGateway,
+						ResourceType: awstypes.ResourceTypeTransitGatewayAttachment,
 						Tags: []awstypes.Tag{
 							{
 								Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", request.Name)),

--- a/controllers/networktopology_test.go
+++ b/controllers/networktopology_test.go
@@ -519,6 +519,10 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					}))
 					Expect(*payload.VpcId).To(Equal(mcVPCId))
 				})
+
+				It("should not create routes on subnet route tables", func() {
+					Expect(transitGatewayClient.CreateRouteCallCount()).To(Equal(0))
+				})
 			})
 
 			When("the cluster has an existing transit gateway but no attachment", func() {
@@ -603,6 +607,10 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					}))
 					Expect(*payload.VpcId).To(Equal(mcVPCId))
 				})
+
+				It("should not create routes on subnet route tables", func() {
+					Expect(transitGatewayClient.CreateRouteCallCount()).To(Equal(0))
+				})
 			})
 
 			When("the cluster has an existing transit gateway and existing attachment", func() {
@@ -674,6 +682,10 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 
 				It("should not create a transit gateway attachment", func() {
 					Expect(transitGatewayClient.CreateTransitGatewayVpcAttachmentCallCount()).To(Equal(0))
+				})
+
+				It("should not create routes on subnet route tables", func() {
+					Expect(transitGatewayClient.CreateRouteCallCount()).To(Equal(0))
 				})
 			})
 

--- a/controllers/networktopology_test.go
+++ b/controllers/networktopology_test.go
@@ -43,6 +43,7 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 		transitGatewayClient *awsfakes.FakeTransitGatewayClient
 
 		transitGatewayID = "abc-123"
+		prefixListID     = "prefix-123"
 		mcVPCId          = "vpc-123"
 		wcVPCId          = "vpc-987"
 
@@ -469,6 +470,20 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 						nil,
 					)
 
+					transitGatewayClient.DescribeManagedPrefixListsReturns(
+						&ec2.DescribeManagedPrefixListsOutput{},
+						nil,
+					)
+
+					transitGatewayClient.CreateManagedPrefixListReturns(
+						&ec2.CreateManagedPrefixListOutput{
+							PrefixList: &awstypes.ManagedPrefixList{
+								PrefixListId: &prefixListID,
+							},
+						},
+						nil,
+					)
+
 					clusterClient = k8sclient.NewCluster(k8sClient, types.NamespacedName{
 						Name:      mcCluster.ObjectMeta.Name,
 						Namespace: mcCluster.ObjectMeta.Namespace,
@@ -568,6 +583,15 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 						nil,
 					)
 
+					transitGatewayClient.DescribeManagedPrefixListsReturns(
+						&ec2.DescribeManagedPrefixListsOutput{
+							PrefixLists: []awstypes.ManagedPrefixList{
+								{PrefixListId: &prefixListID},
+							},
+						},
+						nil,
+					)
+
 					clusterClient = k8sclient.NewCluster(k8sClient, types.NamespacedName{
 						Name:      mcCluster.ObjectMeta.Name,
 						Namespace: mcCluster.ObjectMeta.Namespace,
@@ -656,6 +680,15 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 						fmt.Errorf("Conflict"),
 					)
 
+					transitGatewayClient.DescribeManagedPrefixListsReturns(
+						&ec2.DescribeManagedPrefixListsOutput{
+							PrefixLists: []awstypes.ManagedPrefixList{
+								{PrefixListId: &prefixListID},
+							},
+						},
+						nil,
+					)
+
 					clusterClient = k8sclient.NewCluster(k8sClient, types.NamespacedName{
 						Name:      mcCluster.ObjectMeta.Name,
 						Namespace: mcCluster.ObjectMeta.Namespace,
@@ -738,6 +771,15 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 								TransitGatewayAttachmentId: &transitGatewayID,
 								TransitGatewayId:           &transitGatewayID,
 								VpcId:                      &wcAWSCluster.Spec.NetworkSpec.VPC.ID,
+							},
+						},
+						nil,
+					)
+
+					transitGatewayClient.DescribeManagedPrefixListsReturns(
+						&ec2.DescribeManagedPrefixListsOutput{
+							PrefixLists: []awstypes.ManagedPrefixList{
+								{PrefixListId: &prefixListID},
 							},
 						},
 						nil,
@@ -837,6 +879,15 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 						nil,
 					)
 
+					transitGatewayClient.DescribeManagedPrefixListsReturns(
+						&ec2.DescribeManagedPrefixListsOutput{
+							PrefixLists: []awstypes.ManagedPrefixList{
+								{PrefixListId: &prefixListID},
+							},
+						},
+						nil,
+					)
+
 					clusterClient = k8sclient.NewCluster(k8sClient, types.NamespacedName{
 						Name:      mcCluster.ObjectMeta.Name,
 						Namespace: mcCluster.ObjectMeta.Namespace,
@@ -928,6 +979,15 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					transitGatewayClient.CreateTransitGatewayVpcAttachmentReturns(
 						nil,
 						fmt.Errorf("Conflict"),
+					)
+
+					transitGatewayClient.DescribeManagedPrefixListsReturns(
+						&ec2.DescribeManagedPrefixListsOutput{
+							PrefixLists: []awstypes.ManagedPrefixList{
+								{PrefixListId: &prefixListID},
+							},
+						},
+						nil,
 					)
 
 					clusterClient = k8sclient.NewCluster(k8sClient, types.NamespacedName{

--- a/pkg/aws/awsfakes/fake_transit_gateway_client.go
+++ b/pkg/aws/awsfakes/fake_transit_gateway_client.go
@@ -11,6 +11,21 @@ import (
 )
 
 type FakeTransitGatewayClient struct {
+	CreateRouteStub        func(context.Context, *ec2.CreateRouteInput, ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error)
+	createRouteMutex       sync.RWMutex
+	createRouteArgsForCall []struct {
+		arg1 context.Context
+		arg2 *ec2.CreateRouteInput
+		arg3 []func(*ec2.Options)
+	}
+	createRouteReturns struct {
+		result1 *ec2.CreateRouteOutput
+		result2 error
+	}
+	createRouteReturnsOnCall map[int]struct {
+		result1 *ec2.CreateRouteOutput
+		result2 error
+	}
 	CreateTransitGatewayStub        func(context.Context, *ec2.CreateTransitGatewayInput, ...func(*ec2.Options)) (*ec2.CreateTransitGatewayOutput, error)
 	createTransitGatewayMutex       sync.RWMutex
 	createTransitGatewayArgsForCall []struct {
@@ -71,6 +86,21 @@ type FakeTransitGatewayClient struct {
 		result1 *ec2.DeleteTransitGatewayVpcAttachmentOutput
 		result2 error
 	}
+	DescribeRouteTablesStub        func(context.Context, *ec2.DescribeRouteTablesInput, ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
+	describeRouteTablesMutex       sync.RWMutex
+	describeRouteTablesArgsForCall []struct {
+		arg1 context.Context
+		arg2 *ec2.DescribeRouteTablesInput
+		arg3 []func(*ec2.Options)
+	}
+	describeRouteTablesReturns struct {
+		result1 *ec2.DescribeRouteTablesOutput
+		result2 error
+	}
+	describeRouteTablesReturnsOnCall map[int]struct {
+		result1 *ec2.DescribeRouteTablesOutput
+		result2 error
+	}
 	DescribeTransitGatewayVpcAttachmentsStub        func(context.Context, *ec2.DescribeTransitGatewayVpcAttachmentsInput, ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error)
 	describeTransitGatewayVpcAttachmentsMutex       sync.RWMutex
 	describeTransitGatewayVpcAttachmentsArgsForCall []struct {
@@ -103,6 +133,72 @@ type FakeTransitGatewayClient struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeTransitGatewayClient) CreateRoute(arg1 context.Context, arg2 *ec2.CreateRouteInput, arg3 ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error) {
+	fake.createRouteMutex.Lock()
+	ret, specificReturn := fake.createRouteReturnsOnCall[len(fake.createRouteArgsForCall)]
+	fake.createRouteArgsForCall = append(fake.createRouteArgsForCall, struct {
+		arg1 context.Context
+		arg2 *ec2.CreateRouteInput
+		arg3 []func(*ec2.Options)
+	}{arg1, arg2, arg3})
+	stub := fake.CreateRouteStub
+	fakeReturns := fake.createRouteReturns
+	fake.recordInvocation("CreateRoute", []interface{}{arg1, arg2, arg3})
+	fake.createRouteMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTransitGatewayClient) CreateRouteCallCount() int {
+	fake.createRouteMutex.RLock()
+	defer fake.createRouteMutex.RUnlock()
+	return len(fake.createRouteArgsForCall)
+}
+
+func (fake *FakeTransitGatewayClient) CreateRouteCalls(stub func(context.Context, *ec2.CreateRouteInput, ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error)) {
+	fake.createRouteMutex.Lock()
+	defer fake.createRouteMutex.Unlock()
+	fake.CreateRouteStub = stub
+}
+
+func (fake *FakeTransitGatewayClient) CreateRouteArgsForCall(i int) (context.Context, *ec2.CreateRouteInput, []func(*ec2.Options)) {
+	fake.createRouteMutex.RLock()
+	defer fake.createRouteMutex.RUnlock()
+	argsForCall := fake.createRouteArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTransitGatewayClient) CreateRouteReturns(result1 *ec2.CreateRouteOutput, result2 error) {
+	fake.createRouteMutex.Lock()
+	defer fake.createRouteMutex.Unlock()
+	fake.CreateRouteStub = nil
+	fake.createRouteReturns = struct {
+		result1 *ec2.CreateRouteOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTransitGatewayClient) CreateRouteReturnsOnCall(i int, result1 *ec2.CreateRouteOutput, result2 error) {
+	fake.createRouteMutex.Lock()
+	defer fake.createRouteMutex.Unlock()
+	fake.CreateRouteStub = nil
+	if fake.createRouteReturnsOnCall == nil {
+		fake.createRouteReturnsOnCall = make(map[int]struct {
+			result1 *ec2.CreateRouteOutput
+			result2 error
+		})
+	}
+	fake.createRouteReturnsOnCall[i] = struct {
+		result1 *ec2.CreateRouteOutput
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeTransitGatewayClient) CreateTransitGateway(arg1 context.Context, arg2 *ec2.CreateTransitGatewayInput, arg3 ...func(*ec2.Options)) (*ec2.CreateTransitGatewayOutput, error) {
@@ -369,6 +465,72 @@ func (fake *FakeTransitGatewayClient) DeleteTransitGatewayVpcAttachmentReturnsOn
 	}{result1, result2}
 }
 
+func (fake *FakeTransitGatewayClient) DescribeRouteTables(arg1 context.Context, arg2 *ec2.DescribeRouteTablesInput, arg3 ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
+	fake.describeRouteTablesMutex.Lock()
+	ret, specificReturn := fake.describeRouteTablesReturnsOnCall[len(fake.describeRouteTablesArgsForCall)]
+	fake.describeRouteTablesArgsForCall = append(fake.describeRouteTablesArgsForCall, struct {
+		arg1 context.Context
+		arg2 *ec2.DescribeRouteTablesInput
+		arg3 []func(*ec2.Options)
+	}{arg1, arg2, arg3})
+	stub := fake.DescribeRouteTablesStub
+	fakeReturns := fake.describeRouteTablesReturns
+	fake.recordInvocation("DescribeRouteTables", []interface{}{arg1, arg2, arg3})
+	fake.describeRouteTablesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTransitGatewayClient) DescribeRouteTablesCallCount() int {
+	fake.describeRouteTablesMutex.RLock()
+	defer fake.describeRouteTablesMutex.RUnlock()
+	return len(fake.describeRouteTablesArgsForCall)
+}
+
+func (fake *FakeTransitGatewayClient) DescribeRouteTablesCalls(stub func(context.Context, *ec2.DescribeRouteTablesInput, ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)) {
+	fake.describeRouteTablesMutex.Lock()
+	defer fake.describeRouteTablesMutex.Unlock()
+	fake.DescribeRouteTablesStub = stub
+}
+
+func (fake *FakeTransitGatewayClient) DescribeRouteTablesArgsForCall(i int) (context.Context, *ec2.DescribeRouteTablesInput, []func(*ec2.Options)) {
+	fake.describeRouteTablesMutex.RLock()
+	defer fake.describeRouteTablesMutex.RUnlock()
+	argsForCall := fake.describeRouteTablesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTransitGatewayClient) DescribeRouteTablesReturns(result1 *ec2.DescribeRouteTablesOutput, result2 error) {
+	fake.describeRouteTablesMutex.Lock()
+	defer fake.describeRouteTablesMutex.Unlock()
+	fake.DescribeRouteTablesStub = nil
+	fake.describeRouteTablesReturns = struct {
+		result1 *ec2.DescribeRouteTablesOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTransitGatewayClient) DescribeRouteTablesReturnsOnCall(i int, result1 *ec2.DescribeRouteTablesOutput, result2 error) {
+	fake.describeRouteTablesMutex.Lock()
+	defer fake.describeRouteTablesMutex.Unlock()
+	fake.DescribeRouteTablesStub = nil
+	if fake.describeRouteTablesReturnsOnCall == nil {
+		fake.describeRouteTablesReturnsOnCall = make(map[int]struct {
+			result1 *ec2.DescribeRouteTablesOutput
+			result2 error
+		})
+	}
+	fake.describeRouteTablesReturnsOnCall[i] = struct {
+		result1 *ec2.DescribeRouteTablesOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTransitGatewayClient) DescribeTransitGatewayVpcAttachments(arg1 context.Context, arg2 *ec2.DescribeTransitGatewayVpcAttachmentsInput, arg3 ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error) {
 	fake.describeTransitGatewayVpcAttachmentsMutex.Lock()
 	ret, specificReturn := fake.describeTransitGatewayVpcAttachmentsReturnsOnCall[len(fake.describeTransitGatewayVpcAttachmentsArgsForCall)]
@@ -504,6 +666,8 @@ func (fake *FakeTransitGatewayClient) DescribeTransitGatewaysReturnsOnCall(i int
 func (fake *FakeTransitGatewayClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.createRouteMutex.RLock()
+	defer fake.createRouteMutex.RUnlock()
 	fake.createTransitGatewayMutex.RLock()
 	defer fake.createTransitGatewayMutex.RUnlock()
 	fake.createTransitGatewayVpcAttachmentMutex.RLock()
@@ -512,6 +676,8 @@ func (fake *FakeTransitGatewayClient) Invocations() map[string][][]interface{} {
 	defer fake.deleteTransitGatewayMutex.RUnlock()
 	fake.deleteTransitGatewayVpcAttachmentMutex.RLock()
 	defer fake.deleteTransitGatewayVpcAttachmentMutex.RUnlock()
+	fake.describeRouteTablesMutex.RLock()
+	defer fake.describeRouteTablesMutex.RUnlock()
 	fake.describeTransitGatewayVpcAttachmentsMutex.RLock()
 	defer fake.describeTransitGatewayVpcAttachmentsMutex.RUnlock()
 	fake.describeTransitGatewaysMutex.RLock()

--- a/pkg/aws/awsfakes/fake_transit_gateway_client.go
+++ b/pkg/aws/awsfakes/fake_transit_gateway_client.go
@@ -11,6 +11,21 @@ import (
 )
 
 type FakeTransitGatewayClient struct {
+	CreateManagedPrefixListStub        func(context.Context, *ec2.CreateManagedPrefixListInput, ...func(*ec2.Options)) (*ec2.CreateManagedPrefixListOutput, error)
+	createManagedPrefixListMutex       sync.RWMutex
+	createManagedPrefixListArgsForCall []struct {
+		arg1 context.Context
+		arg2 *ec2.CreateManagedPrefixListInput
+		arg3 []func(*ec2.Options)
+	}
+	createManagedPrefixListReturns struct {
+		result1 *ec2.CreateManagedPrefixListOutput
+		result2 error
+	}
+	createManagedPrefixListReturnsOnCall map[int]struct {
+		result1 *ec2.CreateManagedPrefixListOutput
+		result2 error
+	}
 	CreateRouteStub        func(context.Context, *ec2.CreateRouteInput, ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error)
 	createRouteMutex       sync.RWMutex
 	createRouteArgsForCall []struct {
@@ -56,6 +71,21 @@ type FakeTransitGatewayClient struct {
 		result1 *ec2.CreateTransitGatewayVpcAttachmentOutput
 		result2 error
 	}
+	DeleteRouteStub        func(context.Context, *ec2.DeleteRouteInput, ...func(*ec2.Options)) (*ec2.DeleteRouteOutput, error)
+	deleteRouteMutex       sync.RWMutex
+	deleteRouteArgsForCall []struct {
+		arg1 context.Context
+		arg2 *ec2.DeleteRouteInput
+		arg3 []func(*ec2.Options)
+	}
+	deleteRouteReturns struct {
+		result1 *ec2.DeleteRouteOutput
+		result2 error
+	}
+	deleteRouteReturnsOnCall map[int]struct {
+		result1 *ec2.DeleteRouteOutput
+		result2 error
+	}
 	DeleteTransitGatewayStub        func(context.Context, *ec2.DeleteTransitGatewayInput, ...func(*ec2.Options)) (*ec2.DeleteTransitGatewayOutput, error)
 	deleteTransitGatewayMutex       sync.RWMutex
 	deleteTransitGatewayArgsForCall []struct {
@@ -84,6 +114,21 @@ type FakeTransitGatewayClient struct {
 	}
 	deleteTransitGatewayVpcAttachmentReturnsOnCall map[int]struct {
 		result1 *ec2.DeleteTransitGatewayVpcAttachmentOutput
+		result2 error
+	}
+	DescribeManagedPrefixListsStub        func(context.Context, *ec2.DescribeManagedPrefixListsInput, ...func(*ec2.Options)) (*ec2.DescribeManagedPrefixListsOutput, error)
+	describeManagedPrefixListsMutex       sync.RWMutex
+	describeManagedPrefixListsArgsForCall []struct {
+		arg1 context.Context
+		arg2 *ec2.DescribeManagedPrefixListsInput
+		arg3 []func(*ec2.Options)
+	}
+	describeManagedPrefixListsReturns struct {
+		result1 *ec2.DescribeManagedPrefixListsOutput
+		result2 error
+	}
+	describeManagedPrefixListsReturnsOnCall map[int]struct {
+		result1 *ec2.DescribeManagedPrefixListsOutput
 		result2 error
 	}
 	DescribeRouteTablesStub        func(context.Context, *ec2.DescribeRouteTablesInput, ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
@@ -131,8 +176,89 @@ type FakeTransitGatewayClient struct {
 		result1 *ec2.DescribeTransitGatewaysOutput
 		result2 error
 	}
+	ModifyManagedPrefixListStub        func(context.Context, *ec2.ModifyManagedPrefixListInput, ...func(*ec2.Options)) (*ec2.ModifyManagedPrefixListOutput, error)
+	modifyManagedPrefixListMutex       sync.RWMutex
+	modifyManagedPrefixListArgsForCall []struct {
+		arg1 context.Context
+		arg2 *ec2.ModifyManagedPrefixListInput
+		arg3 []func(*ec2.Options)
+	}
+	modifyManagedPrefixListReturns struct {
+		result1 *ec2.ModifyManagedPrefixListOutput
+		result2 error
+	}
+	modifyManagedPrefixListReturnsOnCall map[int]struct {
+		result1 *ec2.ModifyManagedPrefixListOutput
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeTransitGatewayClient) CreateManagedPrefixList(arg1 context.Context, arg2 *ec2.CreateManagedPrefixListInput, arg3 ...func(*ec2.Options)) (*ec2.CreateManagedPrefixListOutput, error) {
+	fake.createManagedPrefixListMutex.Lock()
+	ret, specificReturn := fake.createManagedPrefixListReturnsOnCall[len(fake.createManagedPrefixListArgsForCall)]
+	fake.createManagedPrefixListArgsForCall = append(fake.createManagedPrefixListArgsForCall, struct {
+		arg1 context.Context
+		arg2 *ec2.CreateManagedPrefixListInput
+		arg3 []func(*ec2.Options)
+	}{arg1, arg2, arg3})
+	stub := fake.CreateManagedPrefixListStub
+	fakeReturns := fake.createManagedPrefixListReturns
+	fake.recordInvocation("CreateManagedPrefixList", []interface{}{arg1, arg2, arg3})
+	fake.createManagedPrefixListMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTransitGatewayClient) CreateManagedPrefixListCallCount() int {
+	fake.createManagedPrefixListMutex.RLock()
+	defer fake.createManagedPrefixListMutex.RUnlock()
+	return len(fake.createManagedPrefixListArgsForCall)
+}
+
+func (fake *FakeTransitGatewayClient) CreateManagedPrefixListCalls(stub func(context.Context, *ec2.CreateManagedPrefixListInput, ...func(*ec2.Options)) (*ec2.CreateManagedPrefixListOutput, error)) {
+	fake.createManagedPrefixListMutex.Lock()
+	defer fake.createManagedPrefixListMutex.Unlock()
+	fake.CreateManagedPrefixListStub = stub
+}
+
+func (fake *FakeTransitGatewayClient) CreateManagedPrefixListArgsForCall(i int) (context.Context, *ec2.CreateManagedPrefixListInput, []func(*ec2.Options)) {
+	fake.createManagedPrefixListMutex.RLock()
+	defer fake.createManagedPrefixListMutex.RUnlock()
+	argsForCall := fake.createManagedPrefixListArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTransitGatewayClient) CreateManagedPrefixListReturns(result1 *ec2.CreateManagedPrefixListOutput, result2 error) {
+	fake.createManagedPrefixListMutex.Lock()
+	defer fake.createManagedPrefixListMutex.Unlock()
+	fake.CreateManagedPrefixListStub = nil
+	fake.createManagedPrefixListReturns = struct {
+		result1 *ec2.CreateManagedPrefixListOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTransitGatewayClient) CreateManagedPrefixListReturnsOnCall(i int, result1 *ec2.CreateManagedPrefixListOutput, result2 error) {
+	fake.createManagedPrefixListMutex.Lock()
+	defer fake.createManagedPrefixListMutex.Unlock()
+	fake.CreateManagedPrefixListStub = nil
+	if fake.createManagedPrefixListReturnsOnCall == nil {
+		fake.createManagedPrefixListReturnsOnCall = make(map[int]struct {
+			result1 *ec2.CreateManagedPrefixListOutput
+			result2 error
+		})
+	}
+	fake.createManagedPrefixListReturnsOnCall[i] = struct {
+		result1 *ec2.CreateManagedPrefixListOutput
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeTransitGatewayClient) CreateRoute(arg1 context.Context, arg2 *ec2.CreateRouteInput, arg3 ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error) {
@@ -333,6 +459,72 @@ func (fake *FakeTransitGatewayClient) CreateTransitGatewayVpcAttachmentReturnsOn
 	}{result1, result2}
 }
 
+func (fake *FakeTransitGatewayClient) DeleteRoute(arg1 context.Context, arg2 *ec2.DeleteRouteInput, arg3 ...func(*ec2.Options)) (*ec2.DeleteRouteOutput, error) {
+	fake.deleteRouteMutex.Lock()
+	ret, specificReturn := fake.deleteRouteReturnsOnCall[len(fake.deleteRouteArgsForCall)]
+	fake.deleteRouteArgsForCall = append(fake.deleteRouteArgsForCall, struct {
+		arg1 context.Context
+		arg2 *ec2.DeleteRouteInput
+		arg3 []func(*ec2.Options)
+	}{arg1, arg2, arg3})
+	stub := fake.DeleteRouteStub
+	fakeReturns := fake.deleteRouteReturns
+	fake.recordInvocation("DeleteRoute", []interface{}{arg1, arg2, arg3})
+	fake.deleteRouteMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTransitGatewayClient) DeleteRouteCallCount() int {
+	fake.deleteRouteMutex.RLock()
+	defer fake.deleteRouteMutex.RUnlock()
+	return len(fake.deleteRouteArgsForCall)
+}
+
+func (fake *FakeTransitGatewayClient) DeleteRouteCalls(stub func(context.Context, *ec2.DeleteRouteInput, ...func(*ec2.Options)) (*ec2.DeleteRouteOutput, error)) {
+	fake.deleteRouteMutex.Lock()
+	defer fake.deleteRouteMutex.Unlock()
+	fake.DeleteRouteStub = stub
+}
+
+func (fake *FakeTransitGatewayClient) DeleteRouteArgsForCall(i int) (context.Context, *ec2.DeleteRouteInput, []func(*ec2.Options)) {
+	fake.deleteRouteMutex.RLock()
+	defer fake.deleteRouteMutex.RUnlock()
+	argsForCall := fake.deleteRouteArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTransitGatewayClient) DeleteRouteReturns(result1 *ec2.DeleteRouteOutput, result2 error) {
+	fake.deleteRouteMutex.Lock()
+	defer fake.deleteRouteMutex.Unlock()
+	fake.DeleteRouteStub = nil
+	fake.deleteRouteReturns = struct {
+		result1 *ec2.DeleteRouteOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTransitGatewayClient) DeleteRouteReturnsOnCall(i int, result1 *ec2.DeleteRouteOutput, result2 error) {
+	fake.deleteRouteMutex.Lock()
+	defer fake.deleteRouteMutex.Unlock()
+	fake.DeleteRouteStub = nil
+	if fake.deleteRouteReturnsOnCall == nil {
+		fake.deleteRouteReturnsOnCall = make(map[int]struct {
+			result1 *ec2.DeleteRouteOutput
+			result2 error
+		})
+	}
+	fake.deleteRouteReturnsOnCall[i] = struct {
+		result1 *ec2.DeleteRouteOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTransitGatewayClient) DeleteTransitGateway(arg1 context.Context, arg2 *ec2.DeleteTransitGatewayInput, arg3 ...func(*ec2.Options)) (*ec2.DeleteTransitGatewayOutput, error) {
 	fake.deleteTransitGatewayMutex.Lock()
 	ret, specificReturn := fake.deleteTransitGatewayReturnsOnCall[len(fake.deleteTransitGatewayArgsForCall)]
@@ -461,6 +653,72 @@ func (fake *FakeTransitGatewayClient) DeleteTransitGatewayVpcAttachmentReturnsOn
 	}
 	fake.deleteTransitGatewayVpcAttachmentReturnsOnCall[i] = struct {
 		result1 *ec2.DeleteTransitGatewayVpcAttachmentOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTransitGatewayClient) DescribeManagedPrefixLists(arg1 context.Context, arg2 *ec2.DescribeManagedPrefixListsInput, arg3 ...func(*ec2.Options)) (*ec2.DescribeManagedPrefixListsOutput, error) {
+	fake.describeManagedPrefixListsMutex.Lock()
+	ret, specificReturn := fake.describeManagedPrefixListsReturnsOnCall[len(fake.describeManagedPrefixListsArgsForCall)]
+	fake.describeManagedPrefixListsArgsForCall = append(fake.describeManagedPrefixListsArgsForCall, struct {
+		arg1 context.Context
+		arg2 *ec2.DescribeManagedPrefixListsInput
+		arg3 []func(*ec2.Options)
+	}{arg1, arg2, arg3})
+	stub := fake.DescribeManagedPrefixListsStub
+	fakeReturns := fake.describeManagedPrefixListsReturns
+	fake.recordInvocation("DescribeManagedPrefixLists", []interface{}{arg1, arg2, arg3})
+	fake.describeManagedPrefixListsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTransitGatewayClient) DescribeManagedPrefixListsCallCount() int {
+	fake.describeManagedPrefixListsMutex.RLock()
+	defer fake.describeManagedPrefixListsMutex.RUnlock()
+	return len(fake.describeManagedPrefixListsArgsForCall)
+}
+
+func (fake *FakeTransitGatewayClient) DescribeManagedPrefixListsCalls(stub func(context.Context, *ec2.DescribeManagedPrefixListsInput, ...func(*ec2.Options)) (*ec2.DescribeManagedPrefixListsOutput, error)) {
+	fake.describeManagedPrefixListsMutex.Lock()
+	defer fake.describeManagedPrefixListsMutex.Unlock()
+	fake.DescribeManagedPrefixListsStub = stub
+}
+
+func (fake *FakeTransitGatewayClient) DescribeManagedPrefixListsArgsForCall(i int) (context.Context, *ec2.DescribeManagedPrefixListsInput, []func(*ec2.Options)) {
+	fake.describeManagedPrefixListsMutex.RLock()
+	defer fake.describeManagedPrefixListsMutex.RUnlock()
+	argsForCall := fake.describeManagedPrefixListsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTransitGatewayClient) DescribeManagedPrefixListsReturns(result1 *ec2.DescribeManagedPrefixListsOutput, result2 error) {
+	fake.describeManagedPrefixListsMutex.Lock()
+	defer fake.describeManagedPrefixListsMutex.Unlock()
+	fake.DescribeManagedPrefixListsStub = nil
+	fake.describeManagedPrefixListsReturns = struct {
+		result1 *ec2.DescribeManagedPrefixListsOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTransitGatewayClient) DescribeManagedPrefixListsReturnsOnCall(i int, result1 *ec2.DescribeManagedPrefixListsOutput, result2 error) {
+	fake.describeManagedPrefixListsMutex.Lock()
+	defer fake.describeManagedPrefixListsMutex.Unlock()
+	fake.DescribeManagedPrefixListsStub = nil
+	if fake.describeManagedPrefixListsReturnsOnCall == nil {
+		fake.describeManagedPrefixListsReturnsOnCall = make(map[int]struct {
+			result1 *ec2.DescribeManagedPrefixListsOutput
+			result2 error
+		})
+	}
+	fake.describeManagedPrefixListsReturnsOnCall[i] = struct {
+		result1 *ec2.DescribeManagedPrefixListsOutput
 		result2 error
 	}{result1, result2}
 }
@@ -663,25 +921,99 @@ func (fake *FakeTransitGatewayClient) DescribeTransitGatewaysReturnsOnCall(i int
 	}{result1, result2}
 }
 
+func (fake *FakeTransitGatewayClient) ModifyManagedPrefixList(arg1 context.Context, arg2 *ec2.ModifyManagedPrefixListInput, arg3 ...func(*ec2.Options)) (*ec2.ModifyManagedPrefixListOutput, error) {
+	fake.modifyManagedPrefixListMutex.Lock()
+	ret, specificReturn := fake.modifyManagedPrefixListReturnsOnCall[len(fake.modifyManagedPrefixListArgsForCall)]
+	fake.modifyManagedPrefixListArgsForCall = append(fake.modifyManagedPrefixListArgsForCall, struct {
+		arg1 context.Context
+		arg2 *ec2.ModifyManagedPrefixListInput
+		arg3 []func(*ec2.Options)
+	}{arg1, arg2, arg3})
+	stub := fake.ModifyManagedPrefixListStub
+	fakeReturns := fake.modifyManagedPrefixListReturns
+	fake.recordInvocation("ModifyManagedPrefixList", []interface{}{arg1, arg2, arg3})
+	fake.modifyManagedPrefixListMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTransitGatewayClient) ModifyManagedPrefixListCallCount() int {
+	fake.modifyManagedPrefixListMutex.RLock()
+	defer fake.modifyManagedPrefixListMutex.RUnlock()
+	return len(fake.modifyManagedPrefixListArgsForCall)
+}
+
+func (fake *FakeTransitGatewayClient) ModifyManagedPrefixListCalls(stub func(context.Context, *ec2.ModifyManagedPrefixListInput, ...func(*ec2.Options)) (*ec2.ModifyManagedPrefixListOutput, error)) {
+	fake.modifyManagedPrefixListMutex.Lock()
+	defer fake.modifyManagedPrefixListMutex.Unlock()
+	fake.ModifyManagedPrefixListStub = stub
+}
+
+func (fake *FakeTransitGatewayClient) ModifyManagedPrefixListArgsForCall(i int) (context.Context, *ec2.ModifyManagedPrefixListInput, []func(*ec2.Options)) {
+	fake.modifyManagedPrefixListMutex.RLock()
+	defer fake.modifyManagedPrefixListMutex.RUnlock()
+	argsForCall := fake.modifyManagedPrefixListArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTransitGatewayClient) ModifyManagedPrefixListReturns(result1 *ec2.ModifyManagedPrefixListOutput, result2 error) {
+	fake.modifyManagedPrefixListMutex.Lock()
+	defer fake.modifyManagedPrefixListMutex.Unlock()
+	fake.ModifyManagedPrefixListStub = nil
+	fake.modifyManagedPrefixListReturns = struct {
+		result1 *ec2.ModifyManagedPrefixListOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTransitGatewayClient) ModifyManagedPrefixListReturnsOnCall(i int, result1 *ec2.ModifyManagedPrefixListOutput, result2 error) {
+	fake.modifyManagedPrefixListMutex.Lock()
+	defer fake.modifyManagedPrefixListMutex.Unlock()
+	fake.ModifyManagedPrefixListStub = nil
+	if fake.modifyManagedPrefixListReturnsOnCall == nil {
+		fake.modifyManagedPrefixListReturnsOnCall = make(map[int]struct {
+			result1 *ec2.ModifyManagedPrefixListOutput
+			result2 error
+		})
+	}
+	fake.modifyManagedPrefixListReturnsOnCall[i] = struct {
+		result1 *ec2.ModifyManagedPrefixListOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTransitGatewayClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.createManagedPrefixListMutex.RLock()
+	defer fake.createManagedPrefixListMutex.RUnlock()
 	fake.createRouteMutex.RLock()
 	defer fake.createRouteMutex.RUnlock()
 	fake.createTransitGatewayMutex.RLock()
 	defer fake.createTransitGatewayMutex.RUnlock()
 	fake.createTransitGatewayVpcAttachmentMutex.RLock()
 	defer fake.createTransitGatewayVpcAttachmentMutex.RUnlock()
+	fake.deleteRouteMutex.RLock()
+	defer fake.deleteRouteMutex.RUnlock()
 	fake.deleteTransitGatewayMutex.RLock()
 	defer fake.deleteTransitGatewayMutex.RUnlock()
 	fake.deleteTransitGatewayVpcAttachmentMutex.RLock()
 	defer fake.deleteTransitGatewayVpcAttachmentMutex.RUnlock()
+	fake.describeManagedPrefixListsMutex.RLock()
+	defer fake.describeManagedPrefixListsMutex.RUnlock()
 	fake.describeRouteTablesMutex.RLock()
 	defer fake.describeRouteTablesMutex.RUnlock()
 	fake.describeTransitGatewayVpcAttachmentsMutex.RLock()
 	defer fake.describeTransitGatewayVpcAttachmentsMutex.RUnlock()
 	fake.describeTransitGatewaysMutex.RLock()
 	defer fake.describeTransitGatewaysMutex.RUnlock()
+	fake.modifyManagedPrefixListMutex.RLock()
+	defer fake.modifyManagedPrefixListMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/aws/ec2Client.go
+++ b/pkg/aws/ec2Client.go
@@ -27,6 +27,11 @@ type TransitGatewayClient interface {
 
 	CreateRoute(ctx context.Context, params *ec2.CreateRouteInput, optFns ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error)
 	DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
+	DeleteRoute(ctx context.Context, params *ec2.DeleteRouteInput, optFns ...func(*ec2.Options)) (*ec2.DeleteRouteOutput, error)
+
+	CreateManagedPrefixList(ctx context.Context, params *ec2.CreateManagedPrefixListInput, optFns ...func(*ec2.Options)) (*ec2.CreateManagedPrefixListOutput, error)
+	DescribeManagedPrefixLists(ctx context.Context, params *ec2.DescribeManagedPrefixListsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeManagedPrefixListsOutput, error)
+	ModifyManagedPrefixList(ctx context.Context, params *ec2.ModifyManagedPrefixListInput, optFns ...func(*ec2.Options)) (*ec2.ModifyManagedPrefixListOutput, error)
 }
 
 type EC2Client struct {
@@ -108,4 +113,20 @@ func (e *EC2Client) CreateRoute(ctx context.Context, params *ec2.CreateRouteInpu
 
 func (e *EC2Client) DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
 	return e.client().DescribeRouteTables(ctx, params, optFns...)
+}
+
+func (e *EC2Client) DeleteRoute(ctx context.Context, params *ec2.DeleteRouteInput, optFns ...func(*ec2.Options)) (*ec2.DeleteRouteOutput, error) {
+	return e.client().DeleteRoute(ctx, params, optFns...)
+}
+
+func (e *EC2Client) CreateManagedPrefixList(ctx context.Context, params *ec2.CreateManagedPrefixListInput, optFns ...func(*ec2.Options)) (*ec2.CreateManagedPrefixListOutput, error) {
+	return e.client().CreateManagedPrefixList(ctx, params, optFns...)
+}
+
+func (e *EC2Client) DescribeManagedPrefixLists(ctx context.Context, params *ec2.DescribeManagedPrefixListsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeManagedPrefixListsOutput, error) {
+	return e.client().DescribeManagedPrefixLists(ctx, params, optFns...)
+}
+
+func (e *EC2Client) ModifyManagedPrefixList(ctx context.Context, params *ec2.ModifyManagedPrefixListInput, optFns ...func(*ec2.Options)) (*ec2.ModifyManagedPrefixListOutput, error) {
+	return e.client().ModifyManagedPrefixList(ctx, params, optFns...)
 }

--- a/pkg/aws/ec2Client.go
+++ b/pkg/aws/ec2Client.go
@@ -18,11 +18,15 @@ import (
 //counterfeiter:generate . TransitGatewayClient
 type TransitGatewayClient interface {
 	CreateTransitGateway(ctx context.Context, params *ec2.CreateTransitGatewayInput, optFns ...func(*ec2.Options)) (*ec2.CreateTransitGatewayOutput, error)
-	CreateTransitGatewayVpcAttachment(ctx context.Context, params *ec2.CreateTransitGatewayVpcAttachmentInput, optFns ...func(*ec2.Options)) (*ec2.CreateTransitGatewayVpcAttachmentOutput, error)
 	DeleteTransitGateway(ctx context.Context, params *ec2.DeleteTransitGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTransitGatewayOutput, error)
-	DeleteTransitGatewayVpcAttachment(ctx context.Context, params *ec2.DeleteTransitGatewayVpcAttachmentInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTransitGatewayVpcAttachmentOutput, error)
 	DescribeTransitGateways(ctx context.Context, params *ec2.DescribeTransitGatewaysInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewaysOutput, error)
+
+	CreateTransitGatewayVpcAttachment(ctx context.Context, params *ec2.CreateTransitGatewayVpcAttachmentInput, optFns ...func(*ec2.Options)) (*ec2.CreateTransitGatewayVpcAttachmentOutput, error)
+	DeleteTransitGatewayVpcAttachment(ctx context.Context, params *ec2.DeleteTransitGatewayVpcAttachmentInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTransitGatewayVpcAttachmentOutput, error)
 	DescribeTransitGatewayVpcAttachments(ctx context.Context, params *ec2.DescribeTransitGatewayVpcAttachmentsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error)
+
+	CreateRoute(ctx context.Context, params *ec2.CreateRouteInput, optFns ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error)
+	DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
 }
 
 type EC2Client struct {
@@ -96,4 +100,12 @@ func (e *EC2Client) DescribeTransitGateways(ctx context.Context, params *ec2.Des
 
 func (e *EC2Client) DescribeTransitGatewayVpcAttachments(ctx context.Context, params *ec2.DescribeTransitGatewayVpcAttachmentsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error) {
 	return e.client().DescribeTransitGatewayVpcAttachments(ctx, params, optFns...)
+}
+
+func (e *EC2Client) CreateRoute(ctx context.Context, params *ec2.CreateRouteInput, optFns ...func(*ec2.Options)) (*ec2.CreateRouteOutput, error) {
+	return e.client().CreateRoute(ctx, params, optFns...)
+}
+
+func (e *EC2Client) DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
+	return e.client().DescribeRouteTables(ctx, params, optFns...)
 }

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -393,15 +393,17 @@ func (r *TransitGateway) addRoute(ctx context.Context, transitGatewayID, cidr *s
 		return err
 	}
 
-	for _, rt := range output.RouteTables {
-		_, err = r.transitGatewayClient.CreateRoute(ctx, &ec2.CreateRouteInput{
-			RouteTableId:         rt.RouteTableId,
-			DestinationCidrBlock: cidr,
-			TransitGatewayId:     transitGatewayID,
-		})
-		if err != nil {
-			logger.Error(err, "Failed to add route to route table")
-			return err
+	if output != nil && len(output.RouteTables) > 0 {
+		for _, rt := range output.RouteTables {
+			_, err = r.transitGatewayClient.CreateRoute(ctx, &ec2.CreateRouteInput{
+				RouteTableId:         rt.RouteTableId,
+				DestinationCidrBlock: cidr,
+				TransitGatewayId:     transitGatewayID,
+			})
+			if err != nil {
+				logger.Error(err, "Failed to add route to route table")
+				return err
+			}
 		}
 	}
 

--- a/pkg/util/annotations/common.go
+++ b/pkg/util/annotations/common.go
@@ -12,4 +12,8 @@ const (
 	// NetworkTopologyTransitGatewayIDAnnotation contains the ID of the Transit Gateway used by the cluster.
 	// This is either the user-provided TGW or the one created by this operator.
 	NetworkTopologyTransitGatewayIDAnnotation = "network-topology.giantswarm.io/transit-gateway"
+
+	// NetworkTopologyPrefixListIDAnnotation contains the ID of the Prefix List containing the CIDRs of all clusters.
+	// This is either the user-provided PL ID or the one created by this operator.
+	NetworkTopologyPrefixListIDAnnotation = "network-topology.giantswarm.io/prefix-list"
 )

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -30,6 +30,12 @@ func SetNetworkTopologyTransitGatewayID(o metav1.Object, transitGatewayID string
 	})
 }
 
+func SetNetworkTopologyPrefixListID(o metav1.Object, prefixListID string) {
+	AddAnnotations(o, map[string]string{
+		NetworkTopologyPrefixListIDAnnotation: prefixListID,
+	})
+}
+
 // GetAnnotation returns the value of the specified annotation.
 func GetAnnotation(o metav1.Object, annotation string) string {
 	annotations := o.GetAnnotations()


### PR DESCRIPTION
This PR:

- adds routes between cluster VPCs via TGW to the subnets route tables

### TODO

- [ ] Add tests covering route table logic
- [ ] Update to handle two-way traffic between MC and WC clusters (all route tables need updating with all CIDRs)

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
