### PR TITLE
Fix prefix list max entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced max entries for prefix list
+
+### Changed
+
+- Refactored logging for cleaner output and less noise
+
+### Added
+
+- Support getting prefix list based on ID in annotation
+
 ## [0.2.2] - 2022-09-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support getting prefix list based on ID in annotation
+- Check for conflicting CIDR when adding to prefix list
 
 ## [0.2.3] - 2022-09-22
 

--- a/pkg/k8sclient/cluster.go
+++ b/pkg/k8sclient/cluster.go
@@ -44,6 +44,10 @@ func (g *Cluster) GetManagementCluster(ctx context.Context) (*capi.Cluster, erro
 	return cluster, microerror.Mask(err)
 }
 
+func (g *Cluster) GetManagementClusterNamespacedName() types.NamespacedName {
+	return g.managementCluster
+}
+
 // GetAWSCluster retrieves an AWSCluster based on the provided namespace/name
 func (g *Cluster) GetAWSCluster(ctx context.Context, namespacedName types.NamespacedName) (*capa.AWSCluster, error) {
 	cluster := &capa.AWSCluster{}

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -150,7 +150,7 @@ func (r *TransitGateway) Register(ctx context.Context, cluster *capi.Cluster) er
 		// Ensure TGW ID is saved back to the current cluster
 		baseCluster = cluster.DeepCopy()
 		annotations.SetNetworkTopologyPrefixListID(cluster, prefixListID)
-		if cluster, err = r.clusterClient.Patch(ctx, cluster, client.MergeFrom(baseCluster)); err != nil {
+		if _, err = r.clusterClient.Patch(ctx, cluster, client.MergeFrom(baseCluster)); err != nil {
 			logger.Error(err, "Failed to patch cluster resource with prefix list ID", "prefixListID", prefixListID)
 			return err
 		}

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -24,6 +24,10 @@ func GetNetworkTopologyTransitGatewayID(o metav1.Object) string {
 	return GetAnnotation(o, NetworkTopologyTransitGatewayIDAnnotation)
 }
 
+func GetNetworkTopologyPrefixListID(o metav1.Object) string {
+	return GetAnnotation(o, NetworkTopologyPrefixListIDAnnotation)
+}
+
 func SetNetworkTopologyTransitGatewayID(o metav1.Object, transitGatewayID string) {
 	AddAnnotations(o, map[string]string{
 		NetworkTopologyTransitGatewayIDAnnotation: transitGatewayID,


### PR DESCRIPTION
This PR:

### Fixed

- Reduced max entries for prefix list

### Changed

- Refactored logging for cleaner output and less noise

### Added

- Support getting prefix list based on ID in annotation
- Check for conflicting CIDR when adding to prefix list

### Testing

Description on how aws-network-topology-operator can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for aws-network-topology-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
