### PR TITLE
Check for route existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't attempt to add same route twice
+
 ## [1.0.0] - 2022-09-23
 
 ### Fixed

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -466,6 +466,14 @@ func (r *TransitGateway) addRoutes(ctx context.Context, transitGatewayID, prefix
 
 	if output != nil && len(output.RouteTables) > 0 {
 		for _, rt := range output.RouteTables {
+
+			for _, route := range rt.Routes {
+				if route.DestinationPrefixListId == prefixListID && route.TransitGatewayId == transitGatewayID {
+					// route already exists, nothing to do
+					return nil
+				}
+			}
+
 			_, err = r.transitGatewayClient.CreateRoute(ctx, &ec2.CreateRouteInput{
 				RouteTableId:            rt.RouteTableId,
 				DestinationPrefixListId: prefixListID,


### PR DESCRIPTION

This PR:

- checks if route already exists before attempting to add it

### Testing

Description on how aws-network-topology-operator can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for aws-network-topology-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
