### PR TITLE
Wait for VPC of new cluster to be ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wait for new VPC to be available
+
 ## [1.0.1] - 2022-09-23
 
 ### Fixed

--- a/controllers/networktopology.go
+++ b/controllers/networktopology.go
@@ -89,6 +89,8 @@ func (r *NetworkTopologyReconciler) reconcileNormal(ctx context.Context, cluster
 				return ctrl.Result{Requeue: false}, nil
 			} else if errors.Is(err, &registrar.TransitGatewayNotAvailableError{}) {
 				return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 1}, nil
+			} else if errors.Is(err, &registrar.VPCNotReadyError{}) {
+				return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 1}, nil
 			}
 
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 10}, microerror.Mask(err)

--- a/controllers/networktopology_test.go
+++ b/controllers/networktopology_test.go
@@ -70,6 +70,12 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					VPC: capa.VPCSpec{
 						ID: vpcID,
 					},
+					Subnets: capa.Subnets{
+						{
+							ID:       "sub-1",
+							IsPublic: false,
+						},
+					},
 				},
 			},
 		}
@@ -131,6 +137,12 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 						VPC: capa.VPCSpec{
 							ID: wcVPCId,
 						},
+						Subnets: capa.Subnets{
+							{
+								ID:       "sub-1",
+								IsPublic: false,
+							},
+						},
 					},
 				},
 			}
@@ -171,6 +183,12 @@ var _ = Describe("NewNetworkTopologyReconciler", func() {
 					NetworkSpec: capa.NetworkSpec{
 						VPC: capa.VPCSpec{
 							ID: mcVPCId,
+						},
+						Subnets: capa.Subnets{
+							{
+								ID:       "sub-1",
+								IsPublic: false,
+							},
 						},
 					},
 				},

--- a/pkg/registrar/errors.go
+++ b/pkg/registrar/errors.go
@@ -30,3 +30,15 @@ func (e *TransitGatewayNotAvailableError) Error() string {
 func (e *TransitGatewayNotAvailableError) Is(target error) bool {
 	return reflect.TypeOf(target) == reflect.TypeOf(e)
 }
+
+type VPCNotReadyError struct {
+	error
+}
+
+func (e *VPCNotReadyError) Error() string {
+	return "transit gateway not available"
+}
+
+func (e *VPCNotReadyError) Is(target error) bool {
+	return reflect.TypeOf(target) == reflect.TypeOf(e)
+}


### PR DESCRIPTION

This PR:

- Wait for new VPC to be available

### Testing

Description on how aws-network-topology-operator can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for aws-network-topology-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
