### PR TITLE
Add finalizer to AWSCluster resource too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add finalizer to AWSCluster resource too
+
 ## [1.0.2] - 2022-09-23
 
 ### Fixed

--- a/pkg/k8sclient/cluster.go
+++ b/pkg/k8sclient/cluster.go
@@ -71,11 +71,29 @@ func (g *Cluster) Patch(ctx context.Context, cluster *capi.Cluster, patch client
 func (g *Cluster) AddFinalizer(ctx context.Context, capiCluster *capi.Cluster, finalizer string) error {
 	originalCluster := capiCluster.DeepCopy()
 	controllerutil.AddFinalizer(capiCluster, finalizer)
-	return g.Client.Patch(ctx, capiCluster, client.MergeFrom(originalCluster))
+	if err := g.Client.Patch(ctx, capiCluster, client.MergeFrom(originalCluster)); err != nil {
+		return err
+	}
+	capaCluster, err := g.GetAWSCluster(ctx, types.NamespacedName{Name: capiCluster.Name, Namespace: capiCluster.Namespace})
+	if err != nil {
+		return err
+	}
+	originalCAPACluster := capaCluster.DeepCopy()
+	controllerutil.AddFinalizer(capaCluster, finalizer)
+	return g.Client.Patch(ctx, capaCluster, client.MergeFrom(originalCAPACluster))
 }
 
 // RemoveFinalizer removes the given finalizer from the cluster
 func (g *Cluster) RemoveFinalizer(ctx context.Context, capiCluster *capi.Cluster, finalizer string) error {
+	capaCluster, err := g.GetAWSCluster(ctx, types.NamespacedName{Name: capiCluster.Name, Namespace: capiCluster.Namespace})
+	// Note: If error is not nil we're going to ignore it and continue removing the finalizer from the CAPI cluster
+	if err == nil {
+		originalCAPACluster := capaCluster.DeepCopy()
+		controllerutil.RemoveFinalizer(capaCluster, finalizer)
+		if err := g.Client.Patch(ctx, capaCluster, client.MergeFrom(originalCAPACluster)); err != nil {
+			return err
+		}
+	}
 	originalCluster := capiCluster.DeepCopy()
 	controllerutil.RemoveFinalizer(capiCluster, finalizer)
 	return g.Client.Patch(ctx, capiCluster, client.MergeFrom(originalCluster))


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how aws-network-topology-operator can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for aws-network-topology-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
