### PR TITLE
Add missing RBAC permissions to create k8s events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing RBAC permissions to create k8s events.
+
 ## [1.2.2] - 2022-11-25
 
 ### Fixed

--- a/helm/aws-network-topology-operator/templates/rbac.yaml
+++ b/helm/aws-network-topology-operator/templates/rbac.yaml
@@ -34,6 +34,12 @@ rules:
       - get
       - create
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
controller errors with

```
'events is forbidden: User "system:serviceaccount:giantswarm:aws-network-topology-operator" cannot create resource "events" in API group "" in the namespace "giantswarm"' (will not retry!)
```


### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
