### PR TITLE
Fix pushing image to AliYun

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,10 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      # Ensure that for every commit to master, and for every new release tag,
+      # Ensure that for every commit to `main`, and for every new release tag,
       # an image gets pushed to the Aliyun registry.
       - architect/push-to-docker:
+          context: architect
           name: push-to-aliyun
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/aws-network-topology-operator"
           username_envar: "ALIYUN_USERNAME"
@@ -64,7 +65,7 @@ workflows:
             - go-build
           filters:
             branches:
-              only: master
+              only: main
             tags:
               only: /^v.*/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix pushing image to AliYun
+
 ## [1.2.4] - 2023-01-03
 
 ### Fixed


### PR DESCRIPTION
Untested because it only runs on `main` branch and release tags. With my latest release, it [failed](https://app.circleci.com/pipelines/github/giantswarm/aws-network-topology-operator/258/workflows/262a9503-68bc-4979-ad74-5f589b5431bf) with

```
#!/bin/bash -eo pipefail
echo -n "${ALIYUN_PASSWORD}" | docker login --username "${ALIYUN_USERNAME}" --password-stdin [...]

Must provide --username with --password-stdin

Exited with code exit status 1
```

So the apparent solution is that we were missing the Circle CI context where the `ALIYUN_USERNAME` environment variable comes from.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [skipped] Make sure `values.yaml` and `values.schema.json` are valid.
