### PR TITLE
Only send SNS message if TGW attachment is in pending approval state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only send SNS message when the Transit Gateway attachment is in pending approval state.
+
 ## [1.3.0] - 2023-01-17
 
 ### Added

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -156,8 +156,7 @@ func (r *TransitGateway) Register(ctx context.Context, cluster *capi.Cluster) er
 			return &TransitGatewayNotAvailableError{}
 		}
 
-		if tgwAttachment.State == types.TransitGatewayAttachmentStateInitiating || tgwAttachment.State == types.TransitGatewayAttachmentStateInitiatingRequest ||
-			tgwAttachment.State == types.TransitGatewayAttachmentStatePending || tgwAttachment.State == types.TransitGatewayAttachmentStatePendingAcceptance {
+		if tgwAttachment.State == types.TransitGatewayAttachmentStatePendingAcceptance {
 			logger.Info("Sending SNS message")
 
 			_, err = r.transitGatewayClient.PublishSNSMessage(ctx, &sns.PublishInput{


### PR DESCRIPTION
The customer was seeing errors because we were asking for the TGW attachment approval repeatedly , even when the TGW attachment was being created or it was already approved. Now we only ask for the attachment if it's in the pending approval state.


### Checklist

- [X] Update changelog in CHANGELOG.md.
- [X] Make sure `values.yaml` and `values.schema.json` are valid.
