### PR TITLE
add targetting specific subnets for transit gateway attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change subnet selection condition for transit gateway attachment.
+
 ## [1.4.0] - 2023-01-19
 
 ### Changed

--- a/pkg/aws/awsfakes/fake_transit_gateway_client.go
+++ b/pkg/aws/awsfakes/fake_transit_gateway_client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
+
 	"github.com/giantswarm/aws-network-topology-operator/pkg/aws"
 )
 

--- a/pkg/aws/awsfakes/fake_transit_gateway_client.go
+++ b/pkg/aws/awsfakes/fake_transit_gateway_client.go
@@ -146,7 +146,7 @@ type FakeTransitGatewayClient struct {
 		result1 *ec2.DescribeRouteTablesOutput
 		result2 error
 	}
-	DescribeSubnetsStub        func(context.Context, *ec2.DescribeSubnetsInput, ...func(*ec2.Options)) (ec2.DescribeSubnetsOutput, error)
+	DescribeSubnetsStub        func(context.Context, *ec2.DescribeSubnetsInput, ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
 	describeSubnetsMutex       sync.RWMutex
 	describeSubnetsArgsForCall []struct {
 		arg1 context.Context
@@ -154,11 +154,11 @@ type FakeTransitGatewayClient struct {
 		arg3 []func(*ec2.Options)
 	}
 	describeSubnetsReturns struct {
-		result1 ec2.DescribeSubnetsOutput
+		result1 *ec2.DescribeSubnetsOutput
 		result2 error
 	}
 	describeSubnetsReturnsOnCall map[int]struct {
-		result1 ec2.DescribeSubnetsOutput
+		result1 *ec2.DescribeSubnetsOutput
 		result2 error
 	}
 	DescribeTransitGatewayVpcAttachmentsStub        func(context.Context, *ec2.DescribeTransitGatewayVpcAttachmentsInput, ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error)
@@ -834,7 +834,7 @@ func (fake *FakeTransitGatewayClient) DescribeRouteTablesReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *FakeTransitGatewayClient) DescribeSubnets(arg1 context.Context, arg2 *ec2.DescribeSubnetsInput, arg3 ...func(*ec2.Options)) (ec2.DescribeSubnetsOutput, error) {
+func (fake *FakeTransitGatewayClient) DescribeSubnets(arg1 context.Context, arg2 *ec2.DescribeSubnetsInput, arg3 ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
 	fake.describeSubnetsMutex.Lock()
 	ret, specificReturn := fake.describeSubnetsReturnsOnCall[len(fake.describeSubnetsArgsForCall)]
 	fake.describeSubnetsArgsForCall = append(fake.describeSubnetsArgsForCall, struct {
@@ -861,7 +861,7 @@ func (fake *FakeTransitGatewayClient) DescribeSubnetsCallCount() int {
 	return len(fake.describeSubnetsArgsForCall)
 }
 
-func (fake *FakeTransitGatewayClient) DescribeSubnetsCalls(stub func(context.Context, *ec2.DescribeSubnetsInput, ...func(*ec2.Options)) (ec2.DescribeSubnetsOutput, error)) {
+func (fake *FakeTransitGatewayClient) DescribeSubnetsCalls(stub func(context.Context, *ec2.DescribeSubnetsInput, ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)) {
 	fake.describeSubnetsMutex.Lock()
 	defer fake.describeSubnetsMutex.Unlock()
 	fake.DescribeSubnetsStub = stub
@@ -874,28 +874,28 @@ func (fake *FakeTransitGatewayClient) DescribeSubnetsArgsForCall(i int) (context
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeTransitGatewayClient) DescribeSubnetsReturns(result1 ec2.DescribeSubnetsOutput, result2 error) {
+func (fake *FakeTransitGatewayClient) DescribeSubnetsReturns(result1 *ec2.DescribeSubnetsOutput, result2 error) {
 	fake.describeSubnetsMutex.Lock()
 	defer fake.describeSubnetsMutex.Unlock()
 	fake.DescribeSubnetsStub = nil
 	fake.describeSubnetsReturns = struct {
-		result1 ec2.DescribeSubnetsOutput
+		result1 *ec2.DescribeSubnetsOutput
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeTransitGatewayClient) DescribeSubnetsReturnsOnCall(i int, result1 ec2.DescribeSubnetsOutput, result2 error) {
+func (fake *FakeTransitGatewayClient) DescribeSubnetsReturnsOnCall(i int, result1 *ec2.DescribeSubnetsOutput, result2 error) {
 	fake.describeSubnetsMutex.Lock()
 	defer fake.describeSubnetsMutex.Unlock()
 	fake.DescribeSubnetsStub = nil
 	if fake.describeSubnetsReturnsOnCall == nil {
 		fake.describeSubnetsReturnsOnCall = make(map[int]struct {
-			result1 ec2.DescribeSubnetsOutput
+			result1 *ec2.DescribeSubnetsOutput
 			result2 error
 		})
 	}
 	fake.describeSubnetsReturnsOnCall[i] = struct {
-		result1 ec2.DescribeSubnetsOutput
+		result1 *ec2.DescribeSubnetsOutput
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/aws/awsfakes/fake_transit_gateway_client.go
+++ b/pkg/aws/awsfakes/fake_transit_gateway_client.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
-
 	"github.com/giantswarm/aws-network-topology-operator/pkg/aws"
 )
 
@@ -145,6 +144,21 @@ type FakeTransitGatewayClient struct {
 	}
 	describeRouteTablesReturnsOnCall map[int]struct {
 		result1 *ec2.DescribeRouteTablesOutput
+		result2 error
+	}
+	DescribeSubnetsStub        func(context.Context, *ec2.DescribeSubnetsInput, ...func(*ec2.Options)) (ec2.DescribeSubnetsOutput, error)
+	describeSubnetsMutex       sync.RWMutex
+	describeSubnetsArgsForCall []struct {
+		arg1 context.Context
+		arg2 *ec2.DescribeSubnetsInput
+		arg3 []func(*ec2.Options)
+	}
+	describeSubnetsReturns struct {
+		result1 ec2.DescribeSubnetsOutput
+		result2 error
+	}
+	describeSubnetsReturnsOnCall map[int]struct {
+		result1 ec2.DescribeSubnetsOutput
 		result2 error
 	}
 	DescribeTransitGatewayVpcAttachmentsStub        func(context.Context, *ec2.DescribeTransitGatewayVpcAttachmentsInput, ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error)
@@ -820,6 +834,72 @@ func (fake *FakeTransitGatewayClient) DescribeRouteTablesReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
+func (fake *FakeTransitGatewayClient) DescribeSubnets(arg1 context.Context, arg2 *ec2.DescribeSubnetsInput, arg3 ...func(*ec2.Options)) (ec2.DescribeSubnetsOutput, error) {
+	fake.describeSubnetsMutex.Lock()
+	ret, specificReturn := fake.describeSubnetsReturnsOnCall[len(fake.describeSubnetsArgsForCall)]
+	fake.describeSubnetsArgsForCall = append(fake.describeSubnetsArgsForCall, struct {
+		arg1 context.Context
+		arg2 *ec2.DescribeSubnetsInput
+		arg3 []func(*ec2.Options)
+	}{arg1, arg2, arg3})
+	stub := fake.DescribeSubnetsStub
+	fakeReturns := fake.describeSubnetsReturns
+	fake.recordInvocation("DescribeSubnets", []interface{}{arg1, arg2, arg3})
+	fake.describeSubnetsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTransitGatewayClient) DescribeSubnetsCallCount() int {
+	fake.describeSubnetsMutex.RLock()
+	defer fake.describeSubnetsMutex.RUnlock()
+	return len(fake.describeSubnetsArgsForCall)
+}
+
+func (fake *FakeTransitGatewayClient) DescribeSubnetsCalls(stub func(context.Context, *ec2.DescribeSubnetsInput, ...func(*ec2.Options)) (ec2.DescribeSubnetsOutput, error)) {
+	fake.describeSubnetsMutex.Lock()
+	defer fake.describeSubnetsMutex.Unlock()
+	fake.DescribeSubnetsStub = stub
+}
+
+func (fake *FakeTransitGatewayClient) DescribeSubnetsArgsForCall(i int) (context.Context, *ec2.DescribeSubnetsInput, []func(*ec2.Options)) {
+	fake.describeSubnetsMutex.RLock()
+	defer fake.describeSubnetsMutex.RUnlock()
+	argsForCall := fake.describeSubnetsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTransitGatewayClient) DescribeSubnetsReturns(result1 ec2.DescribeSubnetsOutput, result2 error) {
+	fake.describeSubnetsMutex.Lock()
+	defer fake.describeSubnetsMutex.Unlock()
+	fake.DescribeSubnetsStub = nil
+	fake.describeSubnetsReturns = struct {
+		result1 ec2.DescribeSubnetsOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTransitGatewayClient) DescribeSubnetsReturnsOnCall(i int, result1 ec2.DescribeSubnetsOutput, result2 error) {
+	fake.describeSubnetsMutex.Lock()
+	defer fake.describeSubnetsMutex.Unlock()
+	fake.DescribeSubnetsStub = nil
+	if fake.describeSubnetsReturnsOnCall == nil {
+		fake.describeSubnetsReturnsOnCall = make(map[int]struct {
+			result1 ec2.DescribeSubnetsOutput
+			result2 error
+		})
+	}
+	fake.describeSubnetsReturnsOnCall[i] = struct {
+		result1 ec2.DescribeSubnetsOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTransitGatewayClient) DescribeTransitGatewayVpcAttachments(arg1 context.Context, arg2 *ec2.DescribeTransitGatewayVpcAttachmentsInput, arg3 ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error) {
 	fake.describeTransitGatewayVpcAttachmentsMutex.Lock()
 	ret, specificReturn := fake.describeTransitGatewayVpcAttachmentsReturnsOnCall[len(fake.describeTransitGatewayVpcAttachmentsArgsForCall)]
@@ -1171,6 +1251,8 @@ func (fake *FakeTransitGatewayClient) Invocations() map[string][][]interface{} {
 	defer fake.describeManagedPrefixListsMutex.RUnlock()
 	fake.describeRouteTablesMutex.RLock()
 	defer fake.describeRouteTablesMutex.RUnlock()
+	fake.describeSubnetsMutex.RLock()
+	defer fake.describeSubnetsMutex.RUnlock()
 	fake.describeTransitGatewayVpcAttachmentsMutex.RLock()
 	defer fake.describeTransitGatewayVpcAttachmentsMutex.RUnlock()
 	fake.describeTransitGatewaysMutex.RLock()

--- a/pkg/aws/ec2Client.go
+++ b/pkg/aws/ec2Client.go
@@ -164,3 +164,11 @@ func (e *EC2Client) GetManagedPrefixListEntries(ctx context.Context, params *ec2
 	}
 	return client.GetManagedPrefixListEntries(ctx, params, optFns...)
 }
+
+func (e *EC2Client) DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	client, err := e.client()
+	if err != nil {
+		return nil, err
+	}
+	return client.DescribeSubnets(ctx, params, optFns...)
+}

--- a/pkg/aws/transitGatewayClient.go
+++ b/pkg/aws/transitGatewayClient.go
@@ -28,7 +28,7 @@ type TransitGatewayClient interface {
 
 	PublishSNSMessage(ctx context.Context, params *sns.PublishInput, optFns ...func(*sns.Options)) (*sns.PublishOutput, error)
 
-	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (ec2.DescribeSubnetsOutput, error)
+	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
 }
 
 type TGWClient struct {

--- a/pkg/aws/transitGatewayClient.go
+++ b/pkg/aws/transitGatewayClient.go
@@ -27,6 +27,8 @@ type TransitGatewayClient interface {
 	GetManagedPrefixListEntries(ctx context.Context, params *ec2.GetManagedPrefixListEntriesInput, optFns ...func(*ec2.Options)) (*ec2.GetManagedPrefixListEntriesOutput, error)
 
 	PublishSNSMessage(ctx context.Context, params *sns.PublishInput, optFns ...func(*sns.Options)) (*sns.PublishOutput, error)
+
+	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (ec2.DescribeSubnetsOutput, error)
 }
 
 type TGWClient struct {
@@ -95,4 +97,9 @@ func (e *TGWClient) GetManagedPrefixListEntries(ctx context.Context, params *ec2
 
 func (e *TGWClient) PublishSNSMessage(ctx context.Context, params *sns.PublishInput, optFns ...func(*sns.Options)) (*sns.PublishOutput, error) {
 	return e.snsClient.PublishSNSMessage(ctx, params, optFns...)
+}
+
+func (e *TGWClient) DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+
+	return e.ec2Client.DescribeSubnets(ctx, params, optFns...)
 }

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -779,9 +779,9 @@ func (r *TransitGateway) getTGWGAttachmentSubnetsOrDefault(ctx context.Context, 
 	result := make([]string, 0)
 	output, err := r.transitGatewayClient.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
 		Filters: []types.Filter{
-			{Name: aws.String(capa.NameKubernetesAWSCloudProviderPrefix + awsCluster.Name), Values: []string{"owned", "shared"}},
-			{Name: aws.String(subnetTGWAttachementslabel), Values: []string{"true"}},
-			{Name: aws.String(subnetRoleLabel), Values: []string{"private"}},
+			{Name: aws.String("tag:" + capa.NameKubernetesAWSCloudProviderPrefix + awsCluster.Name), Values: []string{"owned", "shared"}},
+			{Name: aws.String("tag:" + subnetTGWAttachementslabel), Values: []string{"true"}},
+			{Name: aws.String("tag:" + subnetRoleLabel), Values: []string{"private"}},
 		},
 	})
 	if err != nil {

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -34,7 +34,7 @@ const (
 	PREFIX_LIST_MAX_ENTRIES = 45
 
 	subnetTGWAttachementslabel = "subnet.giantswarm.io/tgw-attachments"
-	subnetRoleLabel            = "sigs.k8s.io/cluster-api-provider-aws/role"
+	subnetRoleLabel            = "github.com/giantswarm/aws-vpc-operator/role"
 )
 
 //counterfeiter:generate . ClusterClient

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -788,10 +788,11 @@ func (r *TransitGateway) getTGWGAttachmentSubnetsOrDefault(ctx context.Context, 
 		return nil, err
 	}
 
-	if len(output.Subnets) == 0 {
+	if output == nil || len(output.Subnets) == 0 {
 		for _, s := range getPrivateSubnetsByAZ(awsCluster.Spec.NetworkSpec.Subnets) {
 			result = append(result, s[0].ID)
 		}
+		return result, nil
 	}
 
 	azMap := make(map[string]bool)

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -776,10 +776,7 @@ func (r *TransitGateway) removeFromPrefixList(ctx context.Context, awsCluster *c
 }
 
 func (r *TransitGateway) getTGWGAttachmentSubnetsOrDefault(ctx context.Context, awsCluster *capa.AWSCluster) ([]string, error) {
-	logger := r.getLogger(ctx)
-
 	result := make([]string, 0)
-	logger.Info("Filter subnets according to tag for TGW attachement", "cluster", awsCluster.Name)
 	output, err := r.transitGatewayClient.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
 		Filters: []types.Filter{
 			{Name: aws.String("tag:" + capa.NameKubernetesAWSCloudProviderPrefix + awsCluster.Name), Values: []string{"owned", "shared"}},
@@ -792,13 +789,12 @@ func (r *TransitGateway) getTGWGAttachmentSubnetsOrDefault(ctx context.Context, 
 	}
 
 	if output == nil || len(output.Subnets) == 0 {
-		logger.Info("could not find subnet with expected tag for TGW attachments,fallback to default behavior", "cluster", awsCluster.Name)
 		for _, s := range getPrivateSubnetsByAZ(awsCluster.Spec.NetworkSpec.Subnets) {
 			result = append(result, s[0].ID)
 		}
 		return result, nil
 	}
-	logger.Info("Found subnets with expected TGW attachment tag", "cluster", awsCluster.Name)
+
 	azMap := make(map[string]bool)
 	for _, subnet := range output.Subnets {
 		if !azMap[*subnet.AvailabilityZone] {

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -776,7 +776,10 @@ func (r *TransitGateway) removeFromPrefixList(ctx context.Context, awsCluster *c
 }
 
 func (r *TransitGateway) getTGWGAttachmentSubnetsOrDefault(ctx context.Context, awsCluster *capa.AWSCluster) ([]string, error) {
+	logger := r.getLogger(ctx)
+
 	result := make([]string, 0)
+	logger.Info("Filter subnets according to tag for TGW attachement", "cluster", awsCluster.Name)
 	output, err := r.transitGatewayClient.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
 		Filters: []types.Filter{
 			{Name: aws.String("tag:" + capa.NameKubernetesAWSCloudProviderPrefix + awsCluster.Name), Values: []string{"owned", "shared"}},
@@ -789,12 +792,13 @@ func (r *TransitGateway) getTGWGAttachmentSubnetsOrDefault(ctx context.Context, 
 	}
 
 	if output == nil || len(output.Subnets) == 0 {
+		logger.Info("could not find subnet with expected tag for TGW attachments,fallback to default behavior", "cluster", awsCluster.Name)
 		for _, s := range getPrivateSubnetsByAZ(awsCluster.Spec.NetworkSpec.Subnets) {
 			result = append(result, s[0].ID)
 		}
 		return result, nil
 	}
-
+	logger.Info("Found subnets with expected TGW attachment tag", "cluster", awsCluster.Name)
 	azMap := make(map[string]bool)
 	for _, subnet := range output.Subnets {
 		if !azMap[*subnet.AvailabilityZone] {


### PR DESCRIPTION
This PR:

- Changes operator to target specific subnets with tag `subnet.giantswarm.io/tgw-attachments: "true"` to attach transit gateway.  Previous behavior stays as fallback method.


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
