### PR TITLE
Update values.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change subnet selection condition for transit gateway attachment.
+- Add default vaulue for `serviceType`.
 
 ## [1.4.0] - 2023-01-19
 

--- a/helm/aws-network-topology-operator/values.schema.json
+++ b/helm/aws-network-topology-operator/values.schema.json
@@ -76,6 +76,9 @@
                 }
             }
         },
+        "serviceType": {
+            "type": "string"
+        },
         "userManaged": {
             "type": "object",
             "properties": {

--- a/helm/aws-network-topology-operator/values.yaml
+++ b/helm/aws-network-topology-operator/values.yaml
@@ -26,3 +26,5 @@ aws:
 userManaged:
   # snsTopic defins the SNS topic to send TGW attatchment requests to when running in UserManaged mode.
   snsTopic: ""
+
+serviceType: "managed"


### PR DESCRIPTION
add a default value for service type otherwise, this will fail to a template without `config` repo

used here https://github.com/giantswarm/aws-network-topology-operator/blob/main/helm/aws-network-topology-operator/templates/_helpers.tpl#L36


```
Release "aws-network-topology-operator" does not exist. Installing it now.
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in NetworkPolicy.metadata.labels.giantswarm.io/service-type
```