### PR TITLE
Use short tag name for TGW attachment subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change subnet selection condition for transit gateway attachment.
 - Add default vaulue for `serviceType`.
+- Use short tag name for TGW attachment subnets.
 
 ## [1.4.0] - 2023-01-19
 

--- a/pkg/registrar/transitgateway.go
+++ b/pkg/registrar/transitgateway.go
@@ -33,7 +33,7 @@ const (
 	// default "Routes per route table" quota of 50.
 	PREFIX_LIST_MAX_ENTRIES = 45
 
-	SubnetTGWAttachementsLabel = "subnet.giantswarm.io/tgw-attachments"
+	SubnetTGWAttachementsLabel = "subnet.giantswarm.io/tgw"
 	subnetRoleLabel            = "github.com/giantswarm/aws-vpc-operator/role"
 )
 


### PR DESCRIPTION
This PR:

- uses short tag name for TGW attachment subnets.


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
