### PR TITLE
Use quay instead of docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `golang.org/x/net` package.
+- Use quay.io instead of docker.io in helm chart
 
 ## [1.7.0] - 2023-07-14
 

--- a/helm/aws-network-topology-operator/values.yaml
+++ b/helm/aws-network-topology-operator/values.yaml
@@ -3,7 +3,7 @@ project:
   commit: "[[ .SHA ]]"
 
 image:
-  registry: docker.io
+  registry: quay.io
   name: giantswarm/aws-network-topology-operator
   tag: "[[ .Version ]]"
   pullPolicy: IfNotPresent


### PR DESCRIPTION
This PR:

- Use quay.io instead of docker.io in helm chart


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
