### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.31.0
+  architect: giantswarm/architect@4.35.5
 
 jobs:
   unit-tests:
@@ -60,33 +60,15 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
+      - architect/push-to-registries:
           context: architect
-          name: push-aws-network-topology-operator-to-quay
-          image: "quay.io/giantswarm/aws-network-topology-operator"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
+          name: push-to-registries
           requires:
-          - go-build
+            - go-build
           filters:
             # Trigger the job also on git tag.
             tags:
               only: /^v.*/
-      - architect/push-to-docker:
-          context: "architect"
-          name: push-aws-network-topology-operator-to-docker
-          image: "docker.io/giantswarm/aws-network-topology-operator"
-          username_envar: "DOCKER_USERNAME"
-          password_envar: "DOCKER_PASSWORD"
-          requires:
-            - go-build
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-      # Ensure that for every commit
-      # there is an app version in the test catalog.
       - architect/push-to-app-catalog:
           context: architect
           name: push-to-app-catalog
@@ -94,8 +76,7 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "aws-network-topology-operator"
           requires:
-          - push-aws-network-topology-operator-to-quay
-          - push-aws-network-topology-operator-to-docker
+            - push-to-registries
           filters:
             # Trigger the job also on git tag.
             tags:
@@ -106,9 +87,8 @@ workflows:
           app_name: "aws-network-topology-operator"
           app_collection_repo: "capa-app-collection"
           requires:
-            - push-aws-network-topology-operator-to-docker
-            - push-aws-network-topology-operator-to-quay
             - push-to-app-catalog
+            - push-to-registries
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [ ] Assign this PR to yourself
- [ ] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [ ] Double-check the job dependecies (`requires`)
- [ ] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!