### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
-
 ### Changed
 
+- Configure `gsoci.azurecr.io` as the default container image registry.
 - Move route table related part to another operator.
 - Update `golang.org/x/net` package.
 

--- a/helm/aws-network-topology-operator/values.yaml
+++ b/helm/aws-network-topology-operator/values.yaml
@@ -3,7 +3,7 @@ project:
   commit: "[[ .SHA ]]"
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/aws-network-topology-operator
   tag: "[[ .Version ]]"
   pullPolicy: IfNotPresent
@@ -41,7 +41,7 @@ securityContext:
     type: RuntimeDefault
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
